### PR TITLE
Add support for provider name contains "-", e.g. google-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Hermit Crab automatically synchronizes the in-use versions per 30 minutes, if th
 
 Hermit Crab only performs a checksum verification on the downloaded archives. For archives that already exist in the implied or explicit directory, checksum verification is not performed.
 
-Hermit Crab allows downloading the archives matching `^terraform-provider-(?P<type>\w+)[_-](?P<version>[\w|\\.]+)[_-](?P<os>[a-z]+)[_-](?P<arch>[a-z0-9]+)([_-].*)?\.zip$`, but it is recommended to follow the [Terraform Release Rules](https://developer.hashicorp.com/terraform/registry/providers/publishing#manually-preparing-a-release).
+Hermit Crab allows downloading the archives matching `^terraform-provider-(?P<type>[\w-]+)[_-](?P<version>[\w|\\.]+)[_-](?P<os>[a-z]+)[_-](?P<arch>[a-z0-9]+)([_-].*)?\.zip$`, but it is recommended to follow the [Terraform Release Rules](https://developer.hashicorp.com/terraform/registry/providers/publishing#manually-preparing-a-release).
 
 # License
 

--- a/pkg/apis/debug/handler.go
+++ b/pkg/apis/debug/handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-
 	"github.com/seal-io/walrus/utils/errorx"
 	"github.com/seal-io/walrus/utils/log"
 	"github.com/seal-io/walrus/utils/version"

--- a/pkg/apis/provider/handler_view.go
+++ b/pkg/apis/provider/handler_view.go
@@ -71,7 +71,7 @@ func (r *DownloadArchiveRequest) SetGinContext(ctx *gin.Context) {
 }
 
 var regexValidArchive = regexp.MustCompile(
-	`^terraform-provider-(?P<type>\w+)[_-](?P<version>[\w|\\.]+)[_-](?P<os>[a-z]+)[_-](?P<arch>[a-z0-9]+)([_-].*)?\.zip$`,
+	`^terraform-provider-(?P<type>[\w-]+)[_-](?P<version>[\w|\\.]+)[_-](?P<os>[a-z]+)[_-](?P<arch>[a-z0-9]+)([_-].*)?\.zip$`,
 )
 
 func (r *DownloadArchiveRequest) Validate() error {

--- a/pkg/apis/runtime/handler.go
+++ b/pkg/apis/runtime/handler.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/seal-io/walrus/utils/errorx"
 	"github.com/seal-io/walrus/utils/log"
 )

--- a/pkg/apis/runtime/middleware_error.go
+++ b/pkg/apis/runtime/middleware_error.go
@@ -78,7 +78,7 @@ func getHttpError(c *gin.Context) (he ErrorResponse) {
 
 	he.StatusText = http.StatusText(he.Status)
 
-	return
+	return he
 }
 
 type ErrorResponse struct {

--- a/pkg/apis/runtime/middleware_observation.go
+++ b/pkg/apis/runtime/middleware_observation.go
@@ -5,11 +5,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
+	humanize "github.com/dustin/go-humanize"
 	"github.com/gin-gonic/gin"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/seal-io/walrus/utils/log"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // SkipLoggingPaths is a RouterOption to ignore logging for the given paths.

--- a/pkg/apis/runtime/middleware_recovery.go
+++ b/pkg/apis/runtime/middleware_recovery.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/seal-io/walrus/utils/log"
 )
 

--- a/pkg/apis/runtime/request.go
+++ b/pkg/apis/runtime/request.go
@@ -36,10 +36,10 @@ func (r RequestPagination) Offset() int {
 func (r RequestPagination) Paging() (limit, offset int, request bool) {
 	request = r.Page > 0
 	if !request {
-		return
+		return limit, offset, request
 	}
 	limit = r.Limit()
 	offset = r.Offset()
 
-	return
+	return limit, offset, request
 }

--- a/pkg/apis/runtime/request_stream.go
+++ b/pkg/apis/runtime/request_stream.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-
 	"github.com/seal-io/walrus/utils/json"
 )
 
@@ -24,12 +23,12 @@ type RequestUnidiStream struct {
 func (r RequestUnidiStream) Write(p []byte) (n int, err error) {
 	n, err = r.conn.Write(p)
 	if err != nil {
-		return
+		return n, err
 	}
 
 	r.conn.Flush()
 
-	return
+	return n, err
 }
 
 // SendMsg sends the given data to client.
@@ -110,7 +109,7 @@ func (r RequestBidiStream) Read(p []byte) (n int, err error) {
 	}
 
 	if err != nil {
-		return
+		return n, err
 	}
 
 	switch msgType {
@@ -120,7 +119,7 @@ func (r RequestBidiStream) Read(p []byte) (n int, err error) {
 			Text: "unresolved message type: binary",
 		}
 
-		return
+		return n, err
 	case websocket.TextMessage:
 	}
 
@@ -130,14 +129,14 @@ func (r RequestBidiStream) Read(p []byte) (n int, err error) {
 		r.connReadBytes.Add(int64(n))
 	}
 
-	return
+	return n, err
 }
 
 // Write implements io.Writer.
 func (r RequestBidiStream) Write(p []byte) (n int, err error) {
 	msgWriter, err := r.conn.NextWriter(websocket.TextMessage)
 	if err != nil {
-		return
+		return n, err
 	}
 
 	defer func() { _ = msgWriter.Close() }()
@@ -148,7 +147,7 @@ func (r RequestBidiStream) Write(p []byte) (n int, err error) {
 		r.connWriteBytes.Add(int64(n))
 	}
 
-	return
+	return n, err
 }
 
 // RecvMsg receives message from client.

--- a/pkg/apis/runtime/response.go
+++ b/pkg/apis/runtime/response.go
@@ -131,7 +131,7 @@ func (r ResponseFile) Render(w http.ResponseWriter) (err error) {
 	}
 	_, err = io.Copy(w, r.Reader)
 
-	return
+	return err
 }
 
 func (r ResponseFile) WriteContentType(w http.ResponseWriter) {

--- a/pkg/apis/runtime/router.go
+++ b/pkg/apis/runtime/router.go
@@ -126,7 +126,7 @@ func (opts RouterOptions) Apply(fn func(o RouterOption) bool) (rOpts RouterOptio
 		}
 	}
 
-	return
+	return rOpts
 }
 
 func NewRouter(options ...RouterOption) IRouter {

--- a/pkg/apis/runtime/router_route.go
+++ b/pkg/apis/runtime/router_route.go
@@ -12,12 +12,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gin-gonic/gin/render"
-	"golang.org/x/exp/slices"
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/seal-io/walrus/utils/errorx"
 	"github.com/seal-io/walrus/utils/log"
 	"github.com/seal-io/walrus/utils/strs"
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/seal-io/hermitcrab/pkg/apis/runtime/bind"
 )
@@ -331,7 +330,7 @@ func (p RouteProfile) DeepCopy() (o RouteProfile) {
 	o = p
 	o.ResourceProfile = p.ResourceProfile.DeepCopy()
 
-	return
+	return o
 }
 
 // Collection of resource route name constants.
@@ -779,7 +778,7 @@ func (p *ResourceProfile) DeepCopy() (o ResourceProfile) {
 	o.ResourcePaths = slices.Clone(p.ResourcePaths)
 	o.ResourcePathRefers = slices.Clone(p.ResourcePathRefers)
 
-	return
+	return o
 }
 
 // Prepend prepends the given resource profile.
@@ -840,13 +839,13 @@ func profileResource(h IResourceHandler) (p ResourceProfile) {
 		p.ResourcePathRefers = []string{strings.ToLower(v.InternalKind())}
 	}
 
-	return
+	return p
 }
 
 // getCustomRoute returns the custom route of the given type.
 func getCustomRoute(t reflect.Type) (method, subpath string, ok bool) {
 	if t == nil {
-		return
+		return method, subpath, ok
 	}
 
 	for t.Kind() == reflect.Pointer {
@@ -854,7 +853,7 @@ func getCustomRoute(t reflect.Type) (method, subpath string, ok bool) {
 	}
 
 	if t.Kind() != reflect.Struct {
-		return
+		return method, subpath, ok
 	}
 
 	for i := 0; i < t.NumField(); i++ {
@@ -882,7 +881,7 @@ func getCustomRoute(t reflect.Type) (method, subpath string, ok bool) {
 		return m, p, true
 	}
 
-	return
+	return method, subpath, ok
 }
 
 // isGinError returns true if the given error is a gin error.

--- a/pkg/apis/runtime/router_route_test.go
+++ b/pkg/apis/runtime/router_route_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/seal-io/walrus/utils/json"
+	"github.com/stretchr/testify/assert"
 )
 
 type H1 struct{}

--- a/pkg/apis/runtime/router_stream.go
+++ b/pkg/apis/runtime/router_stream.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-
 	"github.com/seal-io/walrus/utils/gopool"
 	"github.com/seal-io/walrus/utils/log"
 )
@@ -141,7 +140,7 @@ func doBidiStreamRequest(c *gin.Context, route Route, routeInput reflect.Value) 
 	// if downstream closes, the close handler will be triggered.
 	conn.SetCloseHandler(func(int, string) (err error) {
 		cancel()
-		return
+		return err
 	})
 
 	frc := make(chan struct {

--- a/pkg/apis/runtime/scheme_route.go
+++ b/pkg/apis/runtime/scheme_route.go
@@ -13,13 +13,13 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gin-gonic/gin/render"
+	"github.com/seal-io/walrus/utils/hash"
+	"github.com/seal-io/walrus/utils/strs"
+	"github.com/seal-io/walrus/utils/version"
 	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/seal-io/hermitcrab/pkg/apis/runtime/openapi"
-	"github.com/seal-io/walrus/utils/hash"
-	"github.com/seal-io/walrus/utils/strs"
-	"github.com/seal-io/walrus/utils/version"
 )
 
 var openAPISchemas = &openapi3.T{
@@ -948,5 +948,5 @@ func flattenSchemas(i openapi3.Schemas) (o openapi3.Schemas) {
 		o[pn] = p
 	}
 
-	return
+	return o
 }

--- a/pkg/apis/runtime/scheme_route_openapi.go
+++ b/pkg/apis/runtime/scheme_route_openapi.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/seal-io/walrus/utils/bytespool"
 	"github.com/seal-io/walrus/utils/json"
 )

--- a/pkg/apis/runtime/scheme_route_test.go
+++ b/pkg/apis/runtime/scheme_route_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gin-gonic/gin/render"
 	"github.com/google/uuid"
+	"github.com/seal-io/walrus/utils/json"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/seal-io/hermitcrab/pkg/apis/runtime/openapi"
-	"github.com/seal-io/walrus/utils/json"
 )
 
 type (
@@ -292,7 +292,7 @@ func Test_getOperationParameters(t *testing.T) {
 						Value: pv,
 					},
 				)
-				return
+				return refs
 			}(),
 		},
 		{
@@ -329,7 +329,7 @@ func Test_getOperationParameters(t *testing.T) {
 					},
 				)
 
-				return
+				return refs
 			}(),
 		},
 		{
@@ -341,7 +341,7 @@ func Test_getOperationParameters(t *testing.T) {
 				RequestType: reflect.TypeOf(C{}),
 			},
 			expected: func() (refs openapi3.Parameters) {
-				return
+				return refs
 			}(),
 		},
 		{
@@ -353,7 +353,7 @@ func Test_getOperationParameters(t *testing.T) {
 				RequestType: reflect.TypeOf(D{}),
 			},
 			expected: func() (refs openapi3.Parameters) {
-				return
+				return refs
 			}(),
 		},
 		{
@@ -365,7 +365,7 @@ func Test_getOperationParameters(t *testing.T) {
 				RequestType: reflect.TypeOf(E{}),
 			},
 			expected: func() (refs openapi3.Parameters) {
-				return
+				return refs
 			}(),
 		},
 		{
@@ -402,7 +402,7 @@ func Test_getOperationParameters(t *testing.T) {
 					},
 				)
 
-				return
+				return refs
 			}(),
 		},
 	}

--- a/pkg/apis/server.go
+++ b/pkg/apis/server.go
@@ -11,12 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/crypto/acme"
-	"golang.org/x/crypto/acme/autocert"
-
 	"github.com/seal-io/walrus/utils/dynacert"
 	"github.com/seal-io/walrus/utils/gopool"
 	"github.com/seal-io/walrus/utils/log"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/seal-io/hermitcrab/pkg/apis/config"
 )

--- a/pkg/health/registry.go
+++ b/pkg/health/registry.go
@@ -31,7 +31,7 @@ func Register(ctx context.Context, cs Checkers) (err error) {
 		err = nil
 	})
 
-	return
+	return err
 }
 
 // Check defines the stereotype for health checking.

--- a/pkg/metric/index.go
+++ b/pkg/metric/index.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/seal-io/walrus/utils/log"
 )
 

--- a/pkg/metric/registry.go
+++ b/pkg/metric/registry.go
@@ -35,5 +35,5 @@ func Register(ctx context.Context, cs Collectors) (err error) {
 		}
 	})
 
-	return
+	return err
 }

--- a/pkg/provider/metadata/service.go
+++ b/pkg/provider/metadata/service.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/seal-io/walrus/utils/gopool"
 	"github.com/seal-io/walrus/utils/json"
 	"github.com/seal-io/walrus/utils/log"

--- a/pkg/server/cmd.go
+++ b/pkg/server/cmd.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/urfave/cli/v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 func Command() *cli.Command {

--- a/pkg/server/init_tasks.go
+++ b/pkg/server/init_tasks.go
@@ -20,5 +20,5 @@ func (r *Server) startTasks(ctx context.Context, opts initOptions) (err error) {
 	// Register tasks.
 	err = cron.Schedule(provider.SyncMetadata(ctx, opts.ProviderService))
 
-	return
+	return err
 }

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -17,10 +17,10 @@ import (
 	"github.com/seal-io/walrus/utils/log"
 	"github.com/seal-io/walrus/utils/runtimex"
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli/v2"
+	cli "github.com/urfave/cli/v2"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"github.com/seal-io/hermitcrab/pkg/consts"
 	"github.com/seal-io/hermitcrab/pkg/database"

--- a/pkg/tasks/provider/task.go
+++ b/pkg/tasks/provider/task.go
@@ -16,5 +16,5 @@ func SyncMetadata(_ context.Context, providerService *provider.Service) (name st
 		return providerService.Metadata.Sync(ctx)
 	})
 
-	return
+	return name, expr, task
 }


### PR DESCRIPTION
This pull request updates the regular expression used to validate Terraform provider archive filenames, improving support for provider types that include hyphens.

Validation improvement:

* Updated the `regexValidArchive` regular expression in `pkg/apis/provider/handler_view.go` to allow hyphens in the provider `type` field, enabling validation of archive filenames like `terraform-provider-google-beta_1.0.0_linux_amd64.zip`.